### PR TITLE
Dockerize and improve theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .env
 *.sqlite3
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+ADD requirements.txt /code/
+RUN pip install -r requirements.txt
+ADD . /code/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+#  db:
+#    image: postgres
+  web:
+    build: .
+    command: python3 manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+#    depends_on:
+#      - db
+    environment:
+      - DJANGO_SETTINGS_MODULE=durhamforall.settings.dev-docker
+      - SECRET_KEY=testt

--- a/durhamforall/settings/dev-docker.py
+++ b/durhamforall/settings/dev-docker.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+
+from .base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.getenv("SECRET_KEY")
+
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+ALLOWED_HOSTS = ['*']
+
+try:
+    from .local import *
+except ImportError:
+    pass

--- a/durhamforall/static/css/mobile.css
+++ b/durhamforall/static/css/mobile.css
@@ -429,7 +429,7 @@ textarea[class*="span"],
 [class*=" icon-"]:before,
 .flex-next:before,
 .flex-prev:before {
-    font-family: 'responsive';
+    font-family: FontAwesome;
     font-style: normal;
     font-weight: normal;
     speak: none;

--- a/durhamforall/templates/base.html
+++ b/durhamforall/templates/base.html
@@ -1,35 +1,14 @@
-{% load static wagtailuserbar %}
 <!DOCTYPE html>
-<!--[if lt IE 7]>
-<html class="no-js lt-ie9 lt-ie8 lt-ie7">
-   <![endif]-->
-   <!--[if IE 7]>
-   <html class="no-js lt-ie9 lt-ie8">
-      <![endif]-->
-      <!--[if IE 8]>
-      <html class="no-js lt-ie9">
-         <![endif]-->
-         <!--[if gt IE 8]><!-->
+{% load static wagtailuserbar %}
          <html class="no-js">
-            <!--<![endif]-->
             <head>
                <meta charset="utf-8">
                <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
                <title>Durham For All</title>
                <meta name="viewport" content="width=device-width,initial-scale=1">
                <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
-
                <link rel="stylesheet" href="{% static 'css/mobile.css' %}" type="text/css" />
                <link rel="stylesheet" href="{% static 'css/desktop.css' %}" type="text/css" />
-
-               <!-- <link rel="stylesheet" href="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/tablet-and-desktop.scss" type="text/css" media="screen and (min-width: 768px)" /> -->
-               <!-- because ie8 ignores media queries, we need this -->
-               <!--[if IE 8]>
-               <link rel="stylesheet" href="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/tablet-and-desktop.scss" type="text/css" />
-               <![endif]-->
-               <!--[if IE]>
-               <link rel="stylesheet" href="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/ie.scss" type="text/css" />
-               <![endif]-->
                <script type="text/javascript">var _sf_startpt=(new Date()).getTime()</script>
                <meta name="google-site-verification" content="f2hVuYD16U-6ZPjy_NTk8TBUHQ0dN2FGVnpbmWHxT98" />
                <meta content="authenticity_token" name="csrf-param" />
@@ -40,47 +19,8 @@
                <meta property="og:url" content="http://www.durhamforall.org/">
                <meta property="og:type" content="article">
                <meta property="og:site_name" content="Durham For All"/>
-               <script type="text/javascript">
-                  var NB = NB || {};
-
-                  NB.environment = "production";
-                  NB.pageId = "106";
-                  NB.Liquid = NB.Liquid || {
-                    Theme: {
-                      version: 2,
-                      name: "Publish",
-                      parent: "",
-                      variation: "style_default"
-                    }
-                  };
-                  NB.payments = NB.payments || {elements: {}};
-               </script>
-               <script type="text/javascript">
-                  //<![CDATA[
-                    window._auth_token_name = "authenticity_token";
-                    window._auth_token = "3sO3JMLvXop3JKpHiLl+YuRC7RWH026ocq/nReeSZSs=";
-                  //]]>
-               </script>
                <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/themes/cupertino/jquery-ui.css" type="text/css" media="all">
                <script src="//d3n8a8pro7vhmx.cloudfront.net/assets/liquid/main-bd68292c637d6b45cd01e734458bc5e1c3dd1eecd7987a5d7184acb4f6bce21e.js"></script>
-               <script type="text/javascript">
-                  window.twttr = (function (d,s,id) {
-                    var t, js, fjs = d.getElementsByTagName(s)[0];
-                    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id;
-                    js.src="//platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs);
-                    return window.twttr || (t = { _e: [], ready: function(f){ t._e.push(f) } });
-                  }(document, "script", "twitter-wjs"));
-               </script>
-               <script type="text/javascript">
-                  NB.FBAppId = '126739610711965';
-               </script>
-               <script type="text/javascript">
-                  (function() {
-                    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-                    po.src = '//apis.google.com/js/plusone.js';
-                    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-                  })();
-               </script>
                <script type="text/javascript" src="//use.typekit.com/atg5ome.js"></script>
                <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
                <script type="text/javascript">
@@ -99,25 +39,6 @@
                     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
                   })();
                </script>
-               <script type="text/javascript">
-                  var _qevents = _qevents || [];
-
-                  (function() {
-                   var elem = document.createElement('script');
-
-                   elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
-                   elem.async = true;
-                   elem.type = "text/javascript";
-                   var scpt = document.getElementsByTagName('script')[0];
-                   scpt.parentNode.insertBefore(elem, scpt);
-                  })();
-               </script>
-               <script type="text/javascript">
-                  NB.appConfig.userIsLoggedIn = false;
-               </script>
-               <script type="text/javascript" src="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/jquery.ui.effect.min.js"></script>
-               <script type="text/javascript" src="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/jquery.ui.effect-slide.min.js"></script>
-               <script type="text/javascript" src="http://www.durhamforall.org/themes/3/53b32226bfafd85bcd000004/0/attachments/14626768211504749731/default/staged-donations.js"></script>
                <link href='//fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic|Oswald:400,300,700|Lato:400,700,400italic,700italic|Bree+Serif|Josefin+Sans:700|Bitter:400,700,400italic|Open+Sans:400italic,700italic,400,700,800' rel='stylesheet' type='text/css'>
             </head>
             <body class="aware-theme v2-theme page-type-basic js ">
@@ -168,29 +89,12 @@
                               <header>
                                  <h1 class="title"><a href="/">Durham For All</a></h1>
                               </header>
-                              <div class="header-signup desktop-visible">
-                                 <!-- _signup_form.html -->
-                                 <div class="email-signup form">
-                                    <form id="home_page_new_signup_form" class="ajaxForm signup_form" method="POST" action="/forms/signups" enctype="multipart/form-data">
-                                       <input name="authenticity_token" type="hidden" value="3sO3JMLvXop3JKpHiLl+YuRC7RWH026ocq/nReeSZSs="/><input name="page_id" type="hidden" value="106"/><input name="return_to" type="hidden" value="http://www.durhamforall.org/"/>
-                                       <div class="email_address_form" style="display:none;" aria-hidden="true">
-                                          <p><label for="email_address">Optional email code</label><br/><input name="email_address" type="text" class="text" id="email_address" autocomplete="off"/></p>
-                                       </div>
-                                       <input id="page_id" name="page_id" type="hidden" value="106" />
-                                       <div class="form-errors"></div>
-                                       <input required="required" class="text" id="signup_email" name="signup[email]" placeholder="Email address" type="email" /><input class="submit-button" type="submit" name="commit" value="Join" />
-                                       <div class="form-submit"></div>
-                                    </form>
-                                 </div>
-                                 <!-- /_signup_form.html -->
-                              </div>
                            </div>
                            <!-- .width-container -->
                         </div>
                         <!-- .header-container -->
                         <div class="nav-container desktop-visible">
                            <div class="width-container clearfix">
-                              <!-- _nav.html -->
                               <nav id="menu" role="navigation">
                                  <ul id="topnav" class="topnav desktop-nav">
                                     <li class='active '>
@@ -246,67 +150,19 @@
                                        <div id="content">
                                         {% block content %}
                                         {% endblock %}
-                                          <div class="like-page">
-                                             <strong>Do you like this page?</strong>
-                                             <!-- _like_page.html -->
-                                             <div class="sharetable padtopless clearfix">
-                                                <div class="facebook-cell">
-                                                   <div class="desktop-visible">
-                                                      <fb:like href="http://www.durhamforall.org/" show_faces="false" width="300" colorscheme="light" send="true" action="like"></fb:like>
-                                                   </div>
-                                                   <div class="mobile-visible">
-                                                      <fb:like href="http://www.durhamforall.org/" show_faces="false" width="245" colorscheme="light" send="false" action="like"></fb:like>
-                                                   </div>
-                                                </div>
-                                                <div class="twitter-cell">
-                                                   <a href="http://twitter.com/share" class="twitter-share-button" data-count="none" data-text="Home" data-via="">Tweet</a>
-                                                </div>
-                                                <div class="gplus-cell">
-                                                   <g:plusone count="false" size="medium"></g:plusone>
-                                                </div>
-                                             </div>
-                                             <!-- /_like_page.html -->
                                           </div>
                                        </div>
                                     </div>
-                                 </div>
-                                 <!-- .left_column -->
+                           <!-- .left_column -->
                                  <hr class="mobile-visible"/>
-                                 <div class="right-column">
-                                    <div class="signin-wrap">
-                                       <h3>Sign in with:</h3>
-                                       <ul class="supporter-nav-signin">
-                                          <li><a href="https://durhamforall.nationbuilder.com/users/facebook/connect?page_id=106&scope=public_profile%2Cemail"><i class="fa fa-facebook"></i></a>
-                                          </li>
-                                          <li><a href="/users/twitter/connect?page_id=106"><i class="fa fa-twitter"></i></a></li>
-                                          <li><a href="/login"><i class="fa fa-envelope"></i></a></li>
-                                       </ul>
-                                       <h3>Or sign up:</h3>
-                                       <!-- _signup_form.html -->
-                                       <div class="email-signup form">
-                                          <form id="home_page_new_signup_form" class="ajaxForm signup_form" method="POST" action="/forms/signups" enctype="multipart/form-data">
-                                             <input name="authenticity_token" type="hidden" value="3sO3JMLvXop3JKpHiLl+YuRC7RWH026ocq/nReeSZSs="/><input name="page_id" type="hidden" value="106"/><input name="return_to" type="hidden" value="http://www.durhamforall.org/"/>
-                                             <div class="email_address_form" style="display:none;" aria-hidden="true">
-                                                <p><label for="email_address">Optional email code</label><br/><input name="email_address" type="text" class="text" id="email_address" autocomplete="off"/></p>
-                                             </div>
-                                             <input id="page_id" name="page_id" type="hidden" value="106" />
-                                             <div class="form-errors"></div>
-                                             <input required="required" class="text" id="signup_email" name="signup[email]" placeholder="Email address" type="email" /><input class="submit-button" type="submit" name="commit" value="Join" />
-                                             <div class="form-submit"></div>
-                                          </form>
-                                       </div>
-                                       <!-- /_signup_form.html -->
-                                    </div>
-                                    <a class="button supporter-nav-button" href="/donate">Donate</a>
-                                    <a class="button supporter-nav-button" href="/volunteer">Volunteer</a>
-                                    <a class="button supporter-nav-button" href="/contact_us">Contact Us</a>
-                                    <div class="padtop padbottom">
-                                    </div>
-                                 </div>
-                                 <!-- .right-column -->
+                           <div class="right-column">
+                              <a class="button supporter-nav-button" href="/donate">Donate</a>
+                              <a class="button supporter-nav-button" href="/volunteer">Volunteer</a>
+                              <a class="button supporter-nav-button" href="/contact_us">Contact Us</a>
+                              <div class="padtop padbottom">
                               </div>
-                              <!-- .twocolumn_container -->
-                              <!-- /_columns_2.html -->
+                           </div>
+                        </div>
                            </div>
                            <!-- .main -->
                         </div>
@@ -314,69 +170,17 @@
                         <footer>
                            <div class="width-container clearfix">
                               <div id="fb-root"></div>
-                              <script>
-                                 window.fbAsyncInit = function() {
-                                   FB.init({
-                                     appId      : 126739610711965,
-                                     channelUrl : "//durhamforall.nationbuilder.com/channel.html",
-                                     status     : true,
-                                     version    : "v2.8",
-                                     cookie     : true,
-                                     xfbml      : true
-                                   });
-                                 };
-                                 (function(d, s, id) {
-                                   var js, fjs = d.getElementsByTagName(s)[0];
-                                   if (d.getElementById(id)) return;
-                                   js = d.createElement(s);
-                                   js.id = id;
-                                   js.async = true;
-                                   js.src = "//connect.facebook.net/en_US/sdk.js";
-                                   fjs.parentNode.insertBefore(js, fjs);
-                                 }(document, 'script', 'facebook-jssdk'));
-                              </script>
-                              <script src="//d3n8a8pro7vhmx.cloudfront.net/assets/liquid-042153cc53dbd5cca032b3db1cc2759487be72cb18c0b71962f087c4bb1a1747.js"></script>
-                              <script src="//d3n8a8pro7vhmx.cloudfront.net/assets/tinymce-jquery-5f691325b009406d0dacd55361ef5b1563bafcf15aeb3fccec046a25848df4c8.js"></script>
-                              <iframe src="//www.durhamforall.org/session_pair_phase_1" width="1" height="1" style="display: none;"></iframe>
-                              <script type="text/javascript">
-                                 _qevents.push(
-                                   { qacct:"p-5ftmjaPECGTTU" }
-                                   );
-                              </script>
-                              <noscript>
-                                 <div style="display: none;"><img src="//pixel.quantserve.com/pixel?a.1=p-5ftmjaPECGTTU" height="1" width="1" alt="Quantcast"/></div>
-                              </noscript>
                               <div class="row-fluid">
                                  <div class="span6">
                                  </div>
                                  <div class="span2">
                                  </div>
-                                 <div class="span4 mobile-visible">
-                                    <h4>get updates</h4>
-                                    <div class="email-signup form">
-                                       <form id="sign_up_page_new_signup_form" class="ajaxForm signup_form" method="POST" action="/forms/signups" enctype="multipart/form-data">
-                                          <input name="authenticity_token" type="hidden" value="3sO3JMLvXop3JKpHiLl+YuRC7RWH026ocq/nReeSZSs="/><input name="page_id" type="hidden" value="110"/><input name="return_to" type="hidden" value="http:///sign_up"/>
-                                          <div class="email_address_form" style="display:none;" aria-hidden="true">
-                                             <p><label for="email_address">Optional email code</label><br/><input name="email_address" type="text" class="text" id="email_address" autocomplete="off"/></p>
-                                          </div>
-                                          <input id="page_id" name="page_id" type="hidden" value="110" />
-                                          <div class="form-errors"></div>
-                                          <input required="required" class="text" id="signup_email" name="signup[email]" placeholder="Email address" type="email" /><input class="submit-button" type="submit" name="commit" value="Join" />
-                                          <div class="form-submit"></div>
-                                       </form>
-                                    </div>
                                     <div class="padtopmore">
                                        <fb:like href="http://www.durhamforall.org/" colorscheme="light" width="160"></fb:like>
                                     </div>
                                  </div>
                               </div>
                               <hr/>
-                              <div class="row-fluid">
-                                 <div class="span7 footer-left">
-                                    Sign in with <a href="https://durhamforall.nationbuilder.com/users/facebook/connect?page_id=106&scope=public_profile%2Cemail">Facebook</a>, <a
-                                       href="/users/twitter/connect?page_id=106">Twitter</a> or <a href="/login">email</a>.
-                                 </div>
-                              </div>
                            </div>
                            <!-- .width-container -->
                         </footer>
@@ -386,22 +190,5 @@
                   <!-- #wrap -->
                </div>
                <!-- #pattern -->
-               <script type="text/javascript">
-                  function pollFBCommentBox(widget) {
-                    var fbCommentBoxTimer = window.setInterval(function() {
-                      if($(widget).height() < 100) {
-                        $(widget).removeClass('comment-box-active');
-                        window.clearInterval(fbCommentBoxTimer);
-                      }
-                    }, 1000);
-                  }
-                  FB.Event.subscribe('edge.create', function(href, widget) {
-                    $(widget).addClass('comment-box-active');
-                    pollFBCommentBox(widget);
-                  });
-                  FB.Event.subscribe('edge.remove', function(href, widget) {
-                    $(widget).removeClass('comment-box-active');
-                  });
-               </script>
             </body>
          </html>

--- a/durhamforall/templates/base.html
+++ b/durhamforall/templates/base.html
@@ -20,7 +20,6 @@
                <meta property="og:type" content="article">
                <meta property="og:site_name" content="Durham For All"/>
                <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/themes/cupertino/jquery-ui.css" type="text/css" media="all">
-               <script src="//d3n8a8pro7vhmx.cloudfront.net/assets/liquid/main-bd68292c637d6b45cd01e734458bc5e1c3dd1eecd7987a5d7184acb4f6bce21e.js"></script>
                <script type="text/javascript" src="//use.typekit.com/atg5ome.js"></script>
                <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
                <script type="text/javascript">


### PR DESCRIPTION
@sanajaved7 this PR:

* adds configuration to run the site locally via docker, (which I mainly added because I was having a nightmare of a time setting up virtualenv on my mac). 
* strips out all of the nation-builder specific JS and CSS and widgets from the base template. Some of these widgets we may want to add back in at some point, but I figure that's probably easier done from a clean starting point. I don't have a lot of front-end experience and wasn't sure how important the various IE shims that Nationbuilder had inserted were, so this may be way off-base; let me know.
* Fixes the garbled icon on the "about" menu dropdown.