### PR TITLE
Do not show top-level menu items in their own submenu

### DIFF
--- a/durhamforall/templates/tags/top_menu_children.html
+++ b/durhamforall/templates/tags/top_menu_children.html
@@ -1,8 +1,6 @@
 {% load durhamforall_tags wagtailcore_tags %}
 
 <ul class="dropdown-menu">
-    {# Include link to parent because the parent link is a drop down #}
-    <li><a href="{% pageurl parent %}">{{ parent.title }}</a></li>
     {% for child in menuitems_children %}
         <li><a href="{% pageurl child %}">{{ child.title }}</a></li>
     {% endfor %}


### PR DESCRIPTION
At some point we may need to figure out a more flexible way to handle this but this solves the problem for now.